### PR TITLE
allow passwords/tokens with &

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp
 .yardoc
 _yardoc
 doc/
+
+.idea

--- a/salesforce-backup.rb
+++ b/salesforce-backup.rb
@@ -72,6 +72,8 @@ def login
   puts "Logging in..."
   path = '/services/Soap/u/28.0'
 
+  pwd_token_encoded = @sales_force_passwd_and_sec_token.gsub(/&(?!amp;)/,'&amp;')
+
   inital_data = <<-EOF
 <?xml version="1.0" encoding="utf-8" ?>
 <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -80,11 +82,12 @@ def login
   <env:Body>
     <n1:login xmlns:n1="urn:partner.soap.sforce.com">
       <n1:username>#{@sales_force_user_name}</n1:username>
-      <n1:password>#{@sales_force_passwd_and_sec_token}</n1:password>
+      <n1:password>#{pwd_token_encoded}</n1:password>
     </n1:login>
   </env:Body>
 </env:Envelope>
   EOF
+  puts inital_data
 
   initial_headers = {
     'Content-Type' => 'text/xml; charset=UTF-8',

--- a/salesforce-backup.rb
+++ b/salesforce-backup.rb
@@ -87,7 +87,6 @@ def login
   </env:Body>
 </env:Envelope>
   EOF
-  puts inital_data
 
   initial_headers = {
     'Content-Type' => 'text/xml; charset=UTF-8',


### PR DESCRIPTION
Thank you for this script! One issue we ran into was a password/token with an `&` in it. That needs encoding with `&amp;` I'm brute forcing it -- I haven't worked much with the Ruby ecosystem, so hopefully there's a cleaner way of doing this for more characters...